### PR TITLE
IMPLEMENTED CANCELLED API CASE

### DIFF
--- a/src/chat/ChatInterface.js
+++ b/src/chat/ChatInterface.js
@@ -288,6 +288,9 @@ const ChatInterface = (props) => {
 
       // questionsRef.current - because questions state updates not coming in eventBuzz
       const questions = cloneDeep(state.questions);
+      if(Object.keys(questions).length === 0) {
+        return;
+      }
       /*when resuming the conversation from history, the history data is structured using uuid, so using redId, we can extract the question to be resumed, so need to target the id, present in question with the help of reqId */
       /*function to check the questions are from history */
       const isHistoryAccessed = checkHistoryAccessed(questions)

--- a/src/chat/NewChat.js
+++ b/src/chat/NewChat.js
@@ -1,8 +1,10 @@
+import { abortAdvanceSearch } from "../redux/actions/global.action"
 import { setActiveBoardId, setGptUploadedFiles, updateChatData, setSelectedContext, setCurrentQuestion, setErrorState, setQuickActions } from "../redux/globalSlice"
 import store from "../redux/store"
 
 const NewChat = () => {
     // Set board id as null
+    abortAdvanceSearch()
     store.dispatch(setActiveBoardId(null))
     store.dispatch(updateChatData({}))
     store.dispatch(setGptUploadedFiles(null))

--- a/src/chat/chat-utils.js
+++ b/src/chat/chat-utils.js
@@ -104,6 +104,9 @@ export const constructQuestionPostCall = (data, qId) => {
 
     // data.payload = contains api response
     // data.meta.arg = contains passed params and payload
+    if(data?.payload?.cancelled) {
+        return;
+    }
 
     const state = store.getState().global
     const questions = cloneDeep(state.questions)

--- a/src/redux/actions/global.action.js
+++ b/src/redux/actions/global.action.js
@@ -1,4 +1,5 @@
 import { createAsyncThunk  } from "@reduxjs/toolkit";
+import axios from 'axios';
 import axiosInstance from "../../api/axiosInstance";
 import { handleErrorState } from "../../utils/helpers";
 import { v4 as uuidv4 } from 'uuid';
@@ -81,6 +82,14 @@ export const fetchAgents = createAsyncThunk(
 
 
 let controller;
+
+export const abortAdvanceSearch = () => {
+    if (controller) {
+        controller?.abort();
+        controller = null;
+    }
+};
+
 export const advanceSearch = createAsyncThunk(
     'global/advanceSearch',
     async (arg, thunkAPI) => {
@@ -96,6 +105,10 @@ export const advanceSearch = createAsyncThunk(
             });
             return {...response.data, 'kore-traceid': traceId};
         } catch (error) {
+            // Check whether api is cancelled
+            if (axios.isCancel(error) || error.name === 'CanceledError') {                
+                return thunkAPI.rejectWithValue({ cancelled: true });
+            }
             handleErrorState(error, "Advance Search");
             return thunkAPI.rejectWithValue(error.response.data);
         }

--- a/src/test-comp/ChatInterfaceDemo/ChatInterface.jsx
+++ b/src/test-comp/ChatInterfaceDemo/ChatInterface.jsx
@@ -68,7 +68,7 @@ const ChatInterfaceDemo = () => {
       <div className="chatInterfaceSec">
         <div className="chatSec">
           {messages &&
-            Object.values(messages).map((item) => {
+            Object.values(messages).map((item, index) => {
               if (item?.isTask) return;
               
               // Handle multi_intent_execution separately (pure React)
@@ -78,7 +78,7 @@ const ChatInterfaceDemo = () => {
 
               // For all other templates, use the HTML template renderer
               const assistantIconTemplate = () => {
-                return <div className="logo-icon"><img src="/public/eva-black-svg.svg" alt="AiForWork" /></div>;
+                return <div className="logo-icon" key={index}><img src="/public/eva-black-svg.svg" alt="AiForWork" /></div>;
               };
               
               let html = TemplateRenderer.generateHTMLTemplate(item, {

--- a/src/utils/handleAsyncActions.js
+++ b/src/utils/handleAsyncActions.js
@@ -13,7 +13,12 @@ export const handleAsyncActions = (builder, asyncThunk, stateKey, callback) => {
             }
         })
         .addCase(asyncThunk.rejected, (state, action) => {
-            state[stateKey].status = 'failed';
-            state[stateKey].error = action.payload;
+            // Check if the request was cancelled
+            if (action.payload?.cancelled) {
+                state[stateKey].status = 'cancelled';                
+            } else {
+                state[stateKey].status = 'failed';
+                state[stateKey].error = action.payload;
+            }
         });
 };


### PR DESCRIPTION
Implement cancellation handling in async actions and improve chat interface logic. Added checks for cancelled requests in `handleAsyncActions`, `constructQuestionPostCall`, and `ChatInterface`. Introduced `abortAdvanceSearch` action to manage search cancellations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds request cancellation for advanced search and handles cancelled state across chat flow, plus a streaming guard and minor demo fix.
> 
> - **Advanced Search Cancellation**:
>   - Introduce `AbortController` with `controller.signal` in `advanceSearch`; set `kore-traceid` header.
>   - Add `abortAdvanceSearch()` to abort in-flight requests; invoked in `src/chat/NewChat.js` when starting a new chat.
>   - On cancel, return `rejectWithValue({ cancelled: true })` and abort controller in `cancelAdvancedSearch`.
> - **State Handling**:
>   - In `handleAsyncActions`, set status to `cancelled` on cancelled rejections; otherwise mark `failed`.
>   - In `constructQuestionPostCall`, no-op when `data.payload.cancelled`.
> - **Chat Interface**:
>   - In `contentStreaming`, early-return if `questions` is empty to avoid streaming updates with no context.
> - **Demo/UI**:
>   - Provide stable `key` via `index` to assistant icon in `ChatInterfaceDemo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a79c70bc34bc8206d6ecfff3c56437bbce41cf1f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->