### PR TITLE
Santhosh development

### DIFF
--- a/src/composebar/ComposeBar.js
+++ b/src/composebar/ComposeBar.js
@@ -85,7 +85,7 @@ class ComposeBar {
                         this.showBotComposeBarHeader = Object.values(questions)?.find(question => question?.status === 'threadRunning');
                         if(this.showBotComposeBarHeader){
                             console.log("showBotComposeBarHeader", this.showBotComposeBarHeader);
-                            this.placeholder = `Chat with ${this.showBotComposeBarHeader?.context?.sources?.[0]?.name}`;
+                            this.placeholder = `Chat with ${this.showBotComposeBarHeader?.context?.sources?.[0]?.name || this.showBotComposeBarHeader?.sources?.[0]?.title}`;
                             
                             
                             const botWrapper = this.container.querySelector('.composebar-bot-input-wrapper');


### PR DESCRIPTION
1. FIXED THE UNDEFINED ISSUE IN COMOPOSE BAR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compose bar placeholder now falls back to `sources[0].title` when `context.sources[0].name` is unavailable for active bot threads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fadc62b7aefe7b0d7159b9222dd094da424fee11. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->