### PR TITLE
Santhosh development

### DIFF
--- a/src/chat/ChatInterface.js
+++ b/src/chat/ChatInterface.js
@@ -1,5 +1,5 @@
 import { advanceSearch, cancelAdvancedSearch, stopResponseGeneration } from "../redux/actions/global.action";
-import { setChatInterfaceOptions, setCurrentQuestion, setCustomData, setEnableContextByFollowupContext, setEnabledCustomTemplates, setErrorState } from "../redux/globalSlice"
+import { setChatInterfaceOptions, setCurrentQuestion, setCustomData, setEnableContextByFollowupContext, setEnabledCustomTemplates, setErrorState, setAnsFromChipElements } from "../redux/globalSlice"
 import { updateChatData } from "../redux/globalSlice";
 import store from "../redux/store";
 import { v4 as uuid } from 'uuid';
@@ -467,6 +467,15 @@ const ChatInterface = (props) => {
       let _questions = cloneDeep(state.questions)
       const cQFromStore = state.currentQuestion /*this helps to understand whether the current question is a part of agentic flow using isTask flag */
       let reqId = detail?.data?.reqId
+      /*if the user terminates the questions, thoughts stearming should be stopped and update the questions */
+      if(_questions[reqId]?.status === "completed"){
+        let currentBotConversation = _questions[reqId]?.botConversation
+        if(currentBotConversation){
+          currentBotConversation[detail?.data?.answerMeta?.outputMessageId].status = "completed"
+        }        
+        store.dispatch(updateChatData(_questions))
+        return;
+      }
       /*when resuming the conversation from history, the history data is structured using uuid, so using redId, we can extract the question to be resumed, so need to target the id, present in question with the help of reqId */
       const isHistoryAccessed = checkHistoryAccessed(_questions)
       if(isHistoryAccessed){
@@ -548,6 +557,10 @@ const ChatInterface = (props) => {
       }
     }
 
+    const configureAnsFromChipElements = (payload) => {
+      store.dispatch(setAnsFromChipElements(payload))
+    }
+
     const setAgentContext = (agent) => {
       const agentDetails = {
 			name: agent?.name,
@@ -583,7 +596,8 @@ const ChatInterface = (props) => {
         sendMessage,
         setAgentContext,
         stopBotAnswer,
-      responseFlowGeneration
+        configureAnsFromChipElements,
+        responseFlowGeneration
     }
 }
 

--- a/src/redux/globalSlice.js
+++ b/src/redux/globalSlice.js
@@ -55,7 +55,14 @@ const initialState = {
   enableDebugging: false,
   quickActions: [],
   announcements: {},
-  appMetaData:{}
+  appMetaData:{},
+  ansFromChipElements: {
+    'disableSetAsContext': false,
+    'disableCopyAnswer': false,    
+    'disableExporttoWordDoc': false,
+    'disableFeedback': false,
+    'disableThreeDotMenu': false,
+  }
 };
 
 const globalSlice = createSlice({
@@ -133,6 +140,9 @@ const globalSlice = createSlice({
       },
       setAppMetaData: (state, action) => {
         state.appMetaData = action.payload;
+      },
+      setAnsFromChipElements: (state, action) => {
+        state.ansFromChipElements = {...state.ansFromChipElements, ...action.payload};
       }
     },
     extraReducers: (builder) => {
@@ -259,7 +269,8 @@ export const {
   setEnabledDebugging,
 	setQuickActions,
   setAnnouncements,
-	setAppMetaData
+	setAppMetaData,
+	setAnsFromChipElements
 } = globalSlice.actions;
 
 export default globalSlice;

--- a/src/templateRenderer/functionality/ansFromChip.js
+++ b/src/templateRenderer/functionality/ansFromChip.js
@@ -455,15 +455,52 @@ const AnsFromChipFunctionality = ({ item }) => {
 			});
 		}
 
+		// if (item?.sources?.length === 1) {
+		// 	let chip = document.getElementById(`ansFromChip-${item?.id}`);
+		// 	if (chip && !chip.eventListenerAdded) {
+		// 		chip.addEventListener("click", (e) => {
+		// 			e?.preventDefault();
+		// 			e?.stopPropagation();
+		// 			showDataAction();
+		// 		});
+		// 		chip.eventListenerAdded = true;
+		// 	}
+		// }
+
 		if (item?.sources?.length === 1) {
 			let chip = document.getElementById(`ansFromChip-${item?.id}`);
+
 			if (chip && !chip.eventListenerAdded) {
+				// Add listener to the chip element (capture phase to catch event early)
 				chip.addEventListener("click", (e) => {
 					e?.preventDefault();
 					e?.stopPropagation();
 					showDataAction();
+				}, true);
+
+				// Add listener to all child elements (icon, text span, etc.)				
+				const childElements = chip.querySelectorAll('*');
+				childElements.forEach((child) => {
+					child.addEventListener("click", (e) => {
+						e?.stopPropagation();
+						e?.preventDefault();
+						showDataAction();
+					}, true);
 				});
-				chip.eventListenerAdded = true;
+
+				// Add listener to parent element
+				const parent = chip.parentElement;
+				if (parent && !parent.eventListenerAdded) {
+					parent.addEventListener("click", (e) => {
+						e?.preventDefault();
+						e?.stopPropagation();
+						showDataAction();
+					}, true);
+					parent.eventListenerAdded = true;
+					parent.style.cursor = 'pointer';
+				}
+
+				chip.eventListenerAdded = true;				
 			}
 		}
 

--- a/src/templateRenderer/messageRenderer.js
+++ b/src/templateRenderer/messageRenderer.js
@@ -135,7 +135,7 @@ export function renderTemplateContent(
 	let htmlTemplate = "";
 	htmlTemplate = responseQueryFlow.render(data);
 	/*customQNAAPI is for ms */
-	if(data?.sources?.[0]?.source === "llm" || data?.sources?.[0]?.source === "customQnAAPI"){
+	if(data?.sources?.[0]?.source === "llm" || data?.sources?.[0]?.source === "customQnAAPI" || !data?.hasOwnProperty("sources")){
 		htmlTemplate += TemplateComponents.renderAppAvatar(appMetaData.appName, appMetaData.appIcon, data.timestamp);
 	}
 	if (data.viewType === "threadView" || data.botConversation) {

--- a/src/templateRenderer/templates/ansFromChip.js
+++ b/src/templateRenderer/templates/ansFromChip.js
@@ -142,6 +142,8 @@ const AnsFromChip = ({ item, regeneratingAnswer }) => {
 			source.providerIcon || source.icon
 		).outerHTML;
 
+		const chipTitle = source?.title?.[0]?.toUpperCase() + source?.title?.slice(1) || source?.source || "No subject";
+
 		return `
             <div class="leftWrapperBlock">
                 <span class="koraSpecDr${warning ? " fromWarning" : ""
@@ -150,7 +152,7 @@ const AnsFromChip = ({ item, regeneratingAnswer }) => {
                         ${icon}
                     </div>
                     <span class="krSpecName">${htmlDecode(
-				source?.source?.[0]?.toUpperCase() + source?.source?.slice(1) || "No subject"
+				 chipTitle || "No subject"
 			)}</span>                    
                 </span>
 				${warning
@@ -162,7 +164,7 @@ const AnsFromChip = ({ item, regeneratingAnswer }) => {
 	};
 
 	const chatFilterGroupRenderer = () => {
-		if (!item?.showData || item?.sources?.length !== 1 || !item?.data) {
+		if (!item?.showData) {
 			return '';
 		}
 
@@ -598,6 +600,7 @@ const AnsFromChip = ({ item, regeneratingAnswer }) => {
 	const renderChip = () => {
 		let state = store.getState()?.global;
 		let chipHTML = "";		
+		let chatFilterGroupHTML = "";
 		if (regeneratingAnswer) {
 			chipHTML = regeneratingChipRenderer();
 		} else if (item?.viewType === "table") {
@@ -720,7 +723,9 @@ const AnsFromChip = ({ item, regeneratingAnswer }) => {
 		}
 
 		// Generate the chat filter group content 
-		const chatFilterGroupHTML = chatFilterGroupRenderer();
+		if(item?.hasData || item?.sources?.[0]?.source === "customQnAAPI") {
+			chatFilterGroupHTML = chatFilterGroupRenderer();
+		}
 		
 		// Add chatFilterGroup inside answerFromChipDiv but outside chipHTML
 		const chatFilterGroupWrapper = chatFilterGroupHTML ? `<div>${chatFilterGroupHTML}</div>` : '';

--- a/src/templateRenderer/templates/ansFromChip.js
+++ b/src/templateRenderer/templates/ansFromChip.js
@@ -596,8 +596,8 @@ const AnsFromChip = ({ item, regeneratingAnswer }) => {
 	
 
 	const renderChip = () => {
-		let chipHTML = "";
-
+		let state = store.getState()?.global;
+		let chipHTML = "";		
 		if (regeneratingAnswer) {
 			chipHTML = regeneratingChipRenderer();
 		} else if (item?.viewType === "table") {
@@ -655,8 +655,7 @@ const AnsFromChip = ({ item, regeneratingAnswer }) => {
 					
 					dialog.addEventListener('sl-hide', () => {
 						// Update state to set showGPTDialog = false
-						try {
-							let state = store.getState()?.global;
+						try {							
 							let _questions = cloneDeep(state?.questions);
 							let constId = item?.reqId || item?.id;
 							
@@ -688,20 +687,20 @@ const AnsFromChip = ({ item, regeneratingAnswer }) => {
 		}
 
 		// Add export to Word chip if answer exists
-		if (item?.answer) {
+		if (item?.answer && !state?.ansFromChipElements?.disableExporttoWordDoc) {
 			actionChipsHTML += exportWordChip();
 		}
-		if (item?.sources?.[0]?.canSetAsSourceContext !== false) {
+		if (item?.sources?.[0]?.canSetAsSourceContext !== false && !state?.ansFromChipElements?.disableSetAsContext) {
 			actionChipsHTML += setContextChip();
 		}
 
-		if (!item?.disableFeedback) {
+		if (!item?.disableFeedback && !state?.ansFromChipElements?.disableFeedback) {
 			actionChipsHTML += feedbackChip();
 		}
 
 		// Add three dot menu
 		const checkAvailableActions = getAvailableActions();
-		if (checkAvailableActions?.length > 0) {
+		if (checkAvailableActions?.length > 0 && !state?.ansFromChipElements?.disableThreeDotMenu) {
 			actionChipsHTML += threeDotMenu();
 		}
 

--- a/src/templateRenderer/templates/bot-conversation.js
+++ b/src/templateRenderer/templates/bot-conversation.js
@@ -262,12 +262,12 @@ export function setupTemplates(botConversation) {
 	}
 }
 
-const renderThoughts = (conversation) => {
+const renderThoughts = (conversation, props) => {
 	const uniqueId = `thought-wrapper-${conversation?.messageId}`;
-	const isCollapsed = conversation?.question?.length > 0;
+	const isCollapsed = conversation?.question?.length > 0 || props?.status === "completed";
 	return `
 		<div class='thought-wrapper ${isCollapsed ? 'collapsed' : 'expanded'}' id='${uniqueId}' data-toggle-thoughts>
-			<span class='thoughts-header' id='thoughts-header-${conversation?.messageId}'>Thoughts ${isCollapsed ? `for ${conversation?.thoughts?.[conversation?.thoughts?.length - 1]?.thoughtTime} secs` : ''}</span>
+			<span class='thoughts-header' id='thoughts-header-${conversation?.messageId}'>Thought ${isCollapsed ? `for ${conversation?.thoughts?.[conversation?.thoughts?.length - 1]?.thoughtTime} secs` : ''}</span>
 			<span class='spanIcon'>${cheveronRightIcon({ size: 8, color: "#70707B" })}</span>
 			<div class="expand-thoughts-container">
 				${expandThoughts(conversation)}
@@ -404,7 +404,7 @@ function renderBotConversation(
 	return `
 		${renderConversationAgentIcon(props)}		
         <div class="bot-conversation-wrapper ${props?.status === 'completed' ? 'completed' : ''}" data-message-id="${props?.messageId} id="bot-conversation-wrapper">
-		${conversationWithThoughts ? renderThoughts(conversationWithThoughts) : ""}
+		${conversationWithThoughts ? renderThoughts(conversationWithThoughts, props) : ""}
 			<div class="bot-conversation-content-wrapper ${props?.status === 'completed' ? ' bot-conversation-completed' : ''}">
 				<div class="expand-bot-conversation ${props?.status === 'completed' ? ' conversation-completed' : ''}">
 				<div class="top-header">


### PR DESCRIPTION
1. added support to hide elements of answerfromchip
2. sources for customQnAAPI data
3. added renderAppAvatar support for llm, and answers that dont have sources

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Redux-driven config to hide specific Answer From chip actions, enhances single-source chip click handling and titles, shows app avatar when no sources, and tweaks bot thoughts collapse/labeling and completion handling.
> 
> - **State/Redux**:
>   - Add `global.ansFromChipElements` with flags to disable `Set as Context`, `Copy`, `Export to Word`, `Feedback`, and `Three-dot menu`.
>   - New reducer/action `setAnsFromChipElements`; expose `configureAnsFromChipElements` from `ChatInterface`.
> - **Chat Flow**:
>   - Stop thoughts streaming when a question is marked `completed` in `agentThoughts`.
> - **Templates/UI**:
>   - **Answer From chip (`templates/ansFromChip.js`, functionality)**:
>     - Respect `ansFromChipElements` to conditionally render action chips and menu.
>     - Improve single-source chip click behavior (capture on chip, children, and parent) and set pointer cursor.
>     - Use source title (capitalized) for chip label.
>     - Render chat filter group when `hasData` or `customQnAAPI`; add open-in-new-tab handlers for `customQnAAPI` links.
>   - **Message rendering**:
>     - Render app avatar for `llm`, `customQnAAPI`, or when `sources` are absent.
>   - **Bot conversation**:
>     - Pass props into thoughts renderer; collapse thoughts when completed and adjust header text ("Thought").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a47bc87b83c2f5191d0e0e0b6108f91a995e589. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->