### PR TITLE
Santhosh development

### DIFF
--- a/src/chat/ChatInterface.js
+++ b/src/chat/ChatInterface.js
@@ -1,4 +1,4 @@
-import { advanceSearch, cancelAdvancedSearch, stopResponseGeneration } from "../redux/actions/global.action";
+import { abortAdvanceSearch, advanceSearch, cancelAdvancedSearch, stopResponseGeneration } from "../redux/actions/global.action";
 import { setChatInterfaceOptions, setCurrentQuestion, setCustomData, setEnableContextByFollowupContext, setEnabledCustomTemplates, setErrorState, setAnsFromChipElements } from "../redux/globalSlice"
 import { updateChatData } from "../redux/globalSlice";
 import store from "../redux/store";
@@ -34,7 +34,7 @@ const ChatInterface = (props) => {
     };
 
     const stopBotAnswer = async()=>{
-     
+      abortAdvanceSearch()
         let updatedQuestions = state.questions;
         let cancelledQuestion;
         let currentQuestion = state.currentQuestion;
@@ -409,6 +409,9 @@ const ChatInterface = (props) => {
           /*adding streaming for autonomous agent */
           if(question?.viewType === "threadView" || question?.hasOwnProperty('botConversation')){
             /*while autonomous agent is streaming, need to add the chunked data to the outputId present in botConversation */
+            if(question.status === "completed"){
+              return;
+            }
             if(!question?.botConversation) {
               question.botConversation = {}
             }

--- a/src/chat/ChatInterface.js
+++ b/src/chat/ChatInterface.js
@@ -564,6 +564,10 @@ const ChatInterface = (props) => {
       store.dispatch(setAnsFromChipElements(payload))
     }
 
+    const configureChatInterfaceElements = (payload) => {
+      store.dispatch(setChatInterfaceElements(payload))
+    }
+
     const setAgentContext = (agent) => {
       const agentDetails = {
 			name: agent?.name,
@@ -600,7 +604,8 @@ const ChatInterface = (props) => {
         setAgentContext,
         stopBotAnswer,
         configureAnsFromChipElements,
-        responseFlowGeneration
+        responseFlowGeneration,
+        configureChatInterfaceElements
     }
 }
 

--- a/src/redux/actions/global.action.js
+++ b/src/redux/actions/global.action.js
@@ -115,6 +115,12 @@ export const cancelAdvancedSearch = createAsyncThunk(
     'global/cancelAdvancedSearch',
     async (arg, thunkAPI) => { 
         
+        // Abort the in-flight request immediately before making the cancel API call
+        if (controller) {
+            controller.abort();
+            controller = null;
+        }
+        
         try {   
             let reqdQuestionId = encodeURIComponent(arg.reqId)
 
@@ -123,9 +129,6 @@ export const cancelAdvancedSearch = createAsyncThunk(
                 method: 'POST',
                 data: arg.payload
             });
-
-            controller?.abort();
-            controller = null;
             
             return response.data;
         } catch (error) {

--- a/src/redux/globalSlice.js
+++ b/src/redux/globalSlice.js
@@ -62,6 +62,9 @@ const initialState = {
     'disableExporttoWordDoc': false,
     'disableFeedback': false,
     'disableThreeDotMenu': false,
+  },
+  chatInterfaceElements:{
+    enableAppAvatar: false,
   }
 };
 
@@ -143,6 +146,9 @@ const globalSlice = createSlice({
       },
       setAnsFromChipElements: (state, action) => {
         state.ansFromChipElements = {...state.ansFromChipElements, ...action.payload};
+      },
+      setChatInterfaceElements: (state, action) => {
+        state.chatInterfaceElements = {...state.chatInterfaceElements, ...action.payload};
       }
     },
     extraReducers: (builder) => {
@@ -270,7 +276,8 @@ export const {
 	setQuickActions,
   setAnnouncements,
 	setAppMetaData,
-	setAnsFromChipElements
+	setAnsFromChipElements,
+	setChatInterfaceElements
 } = globalSlice.actions;
 
 export default globalSlice;

--- a/src/templateRenderer/messageRenderer.js
+++ b/src/templateRenderer/messageRenderer.js
@@ -131,12 +131,17 @@ export function renderTemplateContent(
 	userIconTemplate,
 	loadingText
 ) {	
-	const appMetaData = store.getState().global.appMetaData;
+	const state = store.getState().global;
 	let htmlTemplate = "";
 	htmlTemplate = responseQueryFlow.render(data);
 	/*customQNAAPI is for ms */
-	if(data?.sources?.[0]?.source === "llm" || data?.sources?.[0]?.source === "customQnAAPI" || !data?.hasOwnProperty("sources")){
-		htmlTemplate += TemplateComponents.renderAppAvatar(appMetaData.appName, appMetaData.appIcon, data.timestamp);
+	if(state.chatInterfaceElements.enableAppAvatar){
+		if(data?.context?.agentType === "gptAgent"){
+			htmlTemplate += TemplateComponents.renderAppAvatar(data?.context?.title, data?.context?.sources?.[0]?.icon || data?.sources?.[0]?.icon, data.timestamp);
+		}
+		else{
+			htmlTemplate += TemplateComponents.renderAppAvatar(state.appMetaData.appName, state.appMetaData.appIcon, data.timestamp);
+		}
 	}
 	if (data.viewType === "threadView" || data.botConversation) {
 		htmlTemplate += botConversation.render(

--- a/src/templateRenderer/templates/bot-conversation.js
+++ b/src/templateRenderer/templates/bot-conversation.js
@@ -410,9 +410,9 @@ function renderBotConversation(
 				<div class="top-header">
 					<div class="bot-conversation-icon-block">
 						<span class="icon-block">
-							<img src="${props?.sources?.[0]?.icon}" alt="">
+							<img src="${props?.sources?.[0]?.icon || props?.agentIcon}" alt="">
 						</span>
-						<span class="bot-agent-name">${props?.sources?.[0]?.title}</span>
+						<span class="bot-agent-name">${props?.sources?.[0]?.title || props?.agentName}</span>
 					</div>
 					<div class="expandAreaBlock" data-message-id="${props?.messageId}" data-collapsed="false">
 						${MinimizeIcon({ size: 16, color: "#667085" })}
@@ -423,7 +423,7 @@ function renderBotConversation(
 					${conversationsHTML}
 				</div>
 				<div class="bot-conversation-summary" data-message-id="${props?.messageId}" style="display: none;">
-					${props?.answer ? MessageRenderer(props.answer) : ''}
+					${props?.answer ? MessageRenderer(props?.answer) : ''}
 				</div>
 			</div>		
         </div>	


### PR DESCRIPTION
1. fixed the issue where advance search api is not cancelling on click of stop response

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Abort ongoing advanced search requests on stop/cancel and add bot conversation rendering fallbacks with streaming safeguards.
> 
> - **Search/Cancel Flow**:
>   - Introduce `abortAdvanceSearch` and invoke it in `stopBotAnswer` and at the start of `cancelAdvancedSearch` to immediately abort in-flight `advanceSearch` requests.
>   - Ensure controller cleanup when aborting.
> - **Chat Streaming**:
>   - In `contentStreaming`, guard autonomous agent updates by early-returning when `question.status === "completed"` and maintain `botConversation` streaming state.
> - **Bot Conversation UI**:
>   - Use fallbacks for agent icon/name: `props?.sources?.[0]?.icon || props?.agentIcon` and `...title || props?.agentName`.
>   - Safely render summary with `MessageRenderer(props?.answer)`.
> - **Wiring**:
>   - Import and use `abortAdvanceSearch` in `src/chat/ChatInterface.js`; update `src/redux/actions/global.action.js` to manage the shared `AbortController`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beec67c8e4f737c907666e4974c82ce3a3bd5a3b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->