### PR TITLE
Cdn support rk

### DIFF
--- a/src/chatbot/ai4wChatBot.js
+++ b/src/chatbot/ai4wChatBot.js
@@ -9,12 +9,19 @@ const DEFAULT_TITLE = "Eva Assistant";
 const state = {
   initialized: false,
   isOpen: false,
+  isHistoryOpen: false,
   elements: {
     button: null,
     panel: null,
     title: null,
     closeButton: null,
     contentContainer: null,
+    chatHistoryButton: null,
+    historyOverlay: null,
+    historySidebar: null,
+    historyCloseButton: null,
+    historyBody: null,
+    historyContent: null,
   },
 };
 
@@ -54,6 +61,7 @@ const createPanel = (titleText) => {
   closeButton.innerHTML = "×";
 
   const newChatButton = document.createElement("button");
+  newChatButton.type = "button";
   newChatButton.className = "sdk-chatbot-newchat";
   newChatButton.textContent = "New Chat";
 
@@ -62,8 +70,14 @@ const createPanel = (titleText) => {
     NewChat()
   });
 
+  const chatHistoryButton = document.createElement("button");
+  chatHistoryButton.type = "button";
+  chatHistoryButton.className = "sdk-chatbot-newchat sdk-chatbot-chat-history";
+  chatHistoryButton.textContent = "Chat History";
+
   const headerButtonContainer = document.createElement("div");
   headerButtonContainer.className = "eva-sdk-chatbot-header-buttons";
+  headerButtonContainer.appendChild(chatHistoryButton);
   headerButtonContainer.appendChild(newChatButton);
   headerButtonContainer.appendChild(closeButton);
 
@@ -80,7 +94,118 @@ const createPanel = (titleText) => {
   panel.appendChild(header);
   panel.appendChild(body);
 
-  return { panel, title, closeButton, contentContainer };
+  const historyElements = createHistorySidebar();
+  const {
+    overlay,
+    sidebar,
+    closeButton: historyCloseButton,
+    body: historyBody,
+    content: historyContent,
+  } = historyElements;
+  panel.appendChild(overlay);
+
+  return {
+    panel,
+    title,
+    closeButton,
+    contentContainer,
+    chatHistoryButton,
+    historyOverlay: overlay,
+    historySidebar: sidebar,
+    historyCloseButton,
+    historyBody,
+    historyContent,
+  };
+};
+
+const createHistorySidebar = () => {
+  const overlay = document.createElement("div");
+  overlay.className = "eva-sdk-chatbot-history-overlay";
+  overlay.setAttribute("aria-hidden", "true");
+
+  const sidebar = document.createElement("aside");
+  sidebar.className = "eva-sdk-chatbot-history-sidebar";
+  sidebar.setAttribute("role", "dialog");
+  sidebar.setAttribute("aria-label", "Chat History");
+  sidebar.setAttribute("aria-modal", "true");
+
+  const header = document.createElement("div");
+  header.className = "eva-sdk-chatbot-history-header";
+
+  const title = document.createElement("div");
+  title.className = "eva-sdk-chatbot-history-title";
+  title.textContent = "Chat History";
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "eva-sdk-chatbot-history-close";
+  closeButton.setAttribute("aria-label", "Close chat history");
+  closeButton.innerHTML = "×";
+
+  header.appendChild(title);
+  header.appendChild(closeButton);
+
+  const body = document.createElement("div");
+  body.className = "eva-sdk-chatbot-history-body";
+
+  const content = document.createElement("div");
+  content.className = "eva-sdk-chatbot-history-content";
+
+  // Sample structured HTML (can be replaced via setChatHistoryContent)
+  content.innerHTML = `
+    <div class="eva-sdk-chatbot-history-list">
+      <div class='history-item-group'>
+        <div class='history-item-group-title'>Last 7 days</div>
+        <ul class='history-item-group-items'>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+        </ul>
+      </div>
+      <div class='history-item-group'>
+        <div class='history-item-group-title'>Last 7 days</div>
+        <ul class='history-item-group-items'>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Order status</div>
+          </li>
+          <li class='history-item-group-item'>
+            <div class='history-item-group-item-title'>Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet</div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  `;
+  body.appendChild(content);
+
+  sidebar.appendChild(header);
+  sidebar.appendChild(body);
+  overlay.appendChild(sidebar);
+
+  // Clicking outside closes; clicking inside should not.
+  sidebar.addEventListener("click", (e) => e.stopPropagation());
+
+  return { overlay, sidebar, closeButton, body, content };
 };
 
 const ensureElements = (config = {}) => {
@@ -94,7 +219,18 @@ const ensureElements = (config = {}) => {
   const button = createButton(buttonLabel);
   const panelElements = createPanel(titleText);
 
-  const { panel, title, closeButton, contentContainer } = panelElements;
+  const {
+    panel,
+    title,
+    closeButton,
+    contentContainer,
+    chatHistoryButton,
+    historyOverlay: overlay,
+    historySidebar: sidebar,
+    historyCloseButton,
+    historyBody,
+    historyContent,
+  } = panelElements;
 
   button.setAttribute("aria-controls", "eva-sdk-chatbot-panel");
   button.setAttribute("aria-expanded", "false");
@@ -108,6 +244,12 @@ const ensureElements = (config = {}) => {
     title,
     closeButton,
     contentContainer,
+    chatHistoryButton,
+    historyOverlay: overlay,
+    historySidebar: sidebar,
+    historyCloseButton,
+    historyBody,
+    historyContent,
   };
 
   button.addEventListener("click", () => {
@@ -120,6 +262,26 @@ const ensureElements = (config = {}) => {
 
   closeButton.addEventListener("click", () => {
     close();
+  });
+
+  if (chatHistoryButton) {
+    chatHistoryButton.addEventListener("click", (e) => {
+      // Defensive: avoid any form-submit/navigation behavior.
+      e.preventDefault?.();
+      if (state.isHistoryOpen) {
+        closeHistory();
+      } else {
+        openHistory();
+      }
+    });
+  }
+
+  overlay.addEventListener("click", () => {
+    closeHistory();
+  });
+
+  historyCloseButton.addEventListener("click", () => {
+    closeHistory();
   });
 };
 
@@ -151,6 +313,27 @@ const syncPanelState = () => {
   button.setAttribute("aria-expanded", state.isOpen ? "true" : "false");
 };
 
+const syncHistoryState = () => {
+  const { historyOverlay, historySidebar } = state.elements;
+  if (!historyOverlay || !historySidebar) {
+    return;
+  }
+
+  historyOverlay.classList.toggle(
+    "eva-sdk-chatbot-history-overlay--open",
+    state.isHistoryOpen
+  );
+  historySidebar.classList.toggle(
+    "eva-sdk-chatbot-history-sidebar--open",
+    state.isHistoryOpen
+  );
+  historyOverlay.setAttribute("aria-hidden", state.isHistoryOpen ? "false" : "true");
+
+  if (state.isHistoryOpen && state.elements.historyCloseButton) {
+    state.elements.historyCloseButton.focus?.();
+  }
+};
+
 export const init = (config = {}) => {
   if (!ensureDomAvailable()) {
     return null;
@@ -176,6 +359,7 @@ export const init = (config = {}) => {
   }
 
   syncPanelState();
+  syncHistoryState();
   state.initialized = true;
 
   return containerId;
@@ -196,11 +380,51 @@ export const close = () => {
   }
 
   state.isOpen = false;
+  state.isHistoryOpen = false;
   syncPanelState();
+  syncHistoryState();
+};
+
+const openHistory = () => {
+  if (!state.initialized) {
+    return;
+  }
+
+  state.isHistoryOpen = true;
+  syncHistoryState();
+};
+
+const closeHistory = () => {
+  if (!state.initialized) {
+    return;
+  }
+
+  state.isHistoryOpen = false;
+  syncHistoryState();
+};
+
+export const setChatHistoryContent = (html) => {
+  if (!state.initialized) {
+    return;
+  }
+
+  const { historyContent } = state.elements;
+  if (!historyContent) {
+    return;
+  }
+
+  // Allow either DOM Node or HTML string.
+  if (typeof Node !== "undefined" && html instanceof Node) {
+    historyContent.replaceChildren(html);
+    return;
+  }
+
+  historyContent.innerHTML = typeof html === "string" ? html : "";
 };
 
 export const chatBot = {
   init,
   open,
   close,
+  setChatHistoryContent,
 };

--- a/src/chatbot/ai4wChatBot.js
+++ b/src/chatbot/ai4wChatBot.js
@@ -2,6 +2,7 @@ import { initializeSDKRuntime } from "../sdkRuntime";
 import { initializeSDK } from "../config";
 import NewChat from "../chat/NewChat";
 import { unHideRecentAgentsDiv } from "../LandingPageRecentAgents";
+import { createHistorySidebar, initHistoryList } from "./chatbotHistory";
 
 const DEFAULT_CONTAINER_ID = "eva-sdk-chatbot-container";
 const DEFAULT_TITLE = "Eva Assistant";
@@ -23,6 +24,7 @@ const state = {
     historyBody: null,
     historyContent: null,
   },
+  historyUnsubscribe: null,
 };
 
 const ensureDomAvailable = () =>
@@ -118,96 +120,6 @@ const createPanel = (titleText) => {
   };
 };
 
-const createHistorySidebar = () => {
-  const overlay = document.createElement("div");
-  overlay.className = "eva-sdk-chatbot-history-overlay";
-  overlay.setAttribute("aria-hidden", "true");
-
-  const sidebar = document.createElement("aside");
-  sidebar.className = "eva-sdk-chatbot-history-sidebar";
-  sidebar.setAttribute("role", "dialog");
-  sidebar.setAttribute("aria-label", "Chat History");
-  sidebar.setAttribute("aria-modal", "true");
-
-  const header = document.createElement("div");
-  header.className = "eva-sdk-chatbot-history-header";
-
-  const title = document.createElement("div");
-  title.className = "eva-sdk-chatbot-history-title";
-  title.textContent = "Chat History";
-
-  const closeButton = document.createElement("button");
-  closeButton.type = "button";
-  closeButton.className = "eva-sdk-chatbot-history-close";
-  closeButton.setAttribute("aria-label", "Close chat history");
-  closeButton.innerHTML = "×";
-
-  header.appendChild(title);
-  header.appendChild(closeButton);
-
-  const body = document.createElement("div");
-  body.className = "eva-sdk-chatbot-history-body";
-
-  const content = document.createElement("div");
-  content.className = "eva-sdk-chatbot-history-content";
-
-  // Sample structured HTML (can be replaced via setChatHistoryContent)
-  content.innerHTML = `
-    <div class="eva-sdk-chatbot-history-list">
-      <div class='history-item-group'>
-        <div class='history-item-group-title'>Last 7 days</div>
-        <ul class='history-item-group-items'>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-        </ul>
-      </div>
-      <div class='history-item-group'>
-        <div class='history-item-group-title'>Last 7 days</div>
-        <ul class='history-item-group-items'>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Order status</div>
-          </li>
-          <li class='history-item-group-item'>
-            <div class='history-item-group-item-title'>Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet</div>
-          </li>
-        </ul>
-      </div>
-    </div>
-  `;
-  body.appendChild(content);
-
-  sidebar.appendChild(header);
-  sidebar.appendChild(body);
-  overlay.appendChild(sidebar);
-
-  // Clicking outside closes; clicking inside should not.
-  sidebar.addEventListener("click", (e) => e.stopPropagation());
-
-  return { overlay, sidebar, closeButton, body, content };
-};
-
 const ensureElements = (config = {}) => {
   if (state.elements.button && state.elements.panel) {
     return;
@@ -251,6 +163,14 @@ const ensureElements = (config = {}) => {
     historyBody,
     historyContent,
   };
+
+  const listContainer = historyContent?.querySelector(".eva-sdk-chatbot-history-list");
+  if (listContainer && !state.historyUnsubscribe) {
+    const result = initHistoryList(listContainer, {
+      onItemSelect: () => closeHistory(),
+    });
+    if (result) state.historyUnsubscribe = result.unsubscribe;
+  }
 
   button.addEventListener("click", () => {
     if (state.isOpen) {

--- a/src/chatbot/chatbotHistory.js
+++ b/src/chatbot/chatbotHistory.js
@@ -4,7 +4,7 @@ import LoadMoreHistoryData from "../history/LoadMoreHistoryData";
 import store from "../redux/store";
 import { hideRecentAgentsDiv } from "../LandingPageRecentAgents";
 import { segregateHistoryBySections, HISTORY_SECTIONS } from "../utils/helpers";
-import { EllipsisHorizontal } from "../templateRenderer/icons-library";
+import { EllipsisHorizontal, createDeleteIcon, EditIcon } from "../templateRenderer/icons-library";
 
 
 const getHistorySectionsOrdered = (items, timeZone) => {
@@ -130,16 +130,40 @@ const createHistoryItemDropdown = (item, callbacks = {}) => {
   const menu = document.createElement("sl-menu");
   menu.classList.add("eva-sdk-history-item-menu");
   const renameItem = document.createElement("sl-menu-item");
+  renameItem.classList.add("eva-sdk-history-menu-item");
   renameItem.setAttribute("data-action", "rename");
-  renameItem.textContent = "Rename";
+  const renameIcon = document.createElement("span");
+  renameIcon.className = "eva-sdk-history-menu-item-icon";
+  renameIcon.setAttribute("slot", "prefix");
+  renameIcon.innerHTML = EditIcon({ size: 14, color: "#667085", className: "eva-sdk-history-menu-item-svg" });
+  renameItem.appendChild(renameIcon);
+  renameItem.appendChild(document.createTextNode("Rename"));
   const deleteItem = document.createElement("sl-menu-item");
+  deleteItem.classList.add("eva-sdk-history-menu-item", "delete-menu-item", "eva-sdk-history-menu-item--delete");
   deleteItem.setAttribute("data-action", "delete");
-  deleteItem.textContent = "Delete";
+  const deleteIcon = document.createElement("span");
+  deleteIcon.className = "eva-sdk-history-menu-item-icon";
+  deleteIcon.setAttribute("slot", "prefix");
+  deleteIcon.innerHTML = createDeleteIcon({ size: 14, color: "#F04438", className: "eva-sdk-history-menu-item-svg" });
+  deleteItem.appendChild(deleteIcon);
+  deleteItem.appendChild(document.createTextNode("Delete"));
   menu.appendChild(renameItem);
   menu.appendChild(deleteItem);
 
   dropdown.appendChild(trigger);
   dropdown.appendChild(menu);
+
+  const setActive = (isActive) => {
+    const li = dropdown.closest(".history-item-group-item");
+    if (!li) return;
+    li.classList.toggle("active", Boolean(isActive));
+  };
+
+  // Add active state when the menu opens/closes.
+  dropdown.addEventListener("sl-show", () => setActive(true));
+  dropdown.addEventListener("sl-hide", () => setActive(false));
+  // Defensive: ensure active state is removed even if hide lifecycle differs.
+  dropdown.addEventListener("sl-after-hide", () => setActive(false));
 
   renameItem.addEventListener("click", (e) => {
     e.stopPropagation();

--- a/src/chatbot/chatbotHistory.js
+++ b/src/chatbot/chatbotHistory.js
@@ -4,6 +4,7 @@ import LoadMoreHistoryData from "../history/LoadMoreHistoryData";
 import store from "../redux/store";
 import { hideRecentAgentsDiv } from "../LandingPageRecentAgents";
 import { segregateHistoryBySections, HISTORY_SECTIONS } from "../utils/helpers";
+import { EllipsisHorizontal } from "../templateRenderer/icons-library";
 
 
 const getHistorySectionsOrdered = (items, timeZone) => {
@@ -63,10 +64,101 @@ export const createHistorySidebar = () => {
 };
 
 
+const startInlineRename = (listContainer, item, historyInterface) => {
+  const li = listContainer.querySelector(`[data-board-id="${item?.id}"]`);
+  if (!li) return;
+  const row = li.querySelector(".history-item-group-item-row");
+  const titleEl = row?.querySelector(".history-item-group-item-title");
+  if (!row || !titleEl) return;
+
+  const originalName = item?.name?.trim() || "Untitled";
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className = "eva-sdk-history-item-title-input";
+  input.value = originalName;
+  input.setAttribute("aria-label", "Rename history item");
+
+  const save = () => {
+    const newName = input.value.trim() || originalName;
+    input.removeEventListener("blur", onBlur);
+    input.removeEventListener("keydown", onKeyDown);
+    input.replaceWith(titleEl);
+    titleEl.textContent = newName;
+    if (newName !== originalName) {
+      historyInterface.updateHistoryBoardName({ boardId: item.id, newName });
+    }
+  };
+
+  const revert = () => {
+    input.removeEventListener("blur", onBlur);
+    input.removeEventListener("keydown", onKeyDown);
+    input.replaceWith(titleEl);
+    titleEl.textContent = originalName;
+  };
+
+  const onBlur = () => save();
+  const onKeyDown = (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      input.blur();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      revert();
+    }
+  };
+
+  titleEl.replaceWith(input);
+  input.addEventListener("blur", onBlur);
+  input.addEventListener("keydown", onKeyDown);
+  input.focus();
+  input.select();
+};
+
+const createHistoryItemDropdown = (item, callbacks = {}) => {
+  const { onRename, onDelete } = callbacks;
+  const dropdown = document.createElement("sl-dropdown");
+  dropdown.classList.add("eva-sdk-history-item-dropdown");
+  dropdown.setAttribute("hoist", "");
+
+  const trigger = document.createElement("button");
+  trigger.type = "button";
+  trigger.className = "eva-sdk-history-item-menu-trigger";
+  trigger.setAttribute("aria-label", "More options");
+  trigger.setAttribute("slot", "trigger");
+  trigger.innerHTML = EllipsisHorizontal({ size: 16, color: "#70707B", className: "eva-sdk-history-item-menu-icon" });
+
+  const menu = document.createElement("sl-menu");
+  menu.classList.add("eva-sdk-history-item-menu");
+  const renameItem = document.createElement("sl-menu-item");
+  renameItem.setAttribute("data-action", "rename");
+  renameItem.textContent = "Rename";
+  const deleteItem = document.createElement("sl-menu-item");
+  deleteItem.setAttribute("data-action", "delete");
+  deleteItem.textContent = "Delete";
+  menu.appendChild(renameItem);
+  menu.appendChild(deleteItem);
+
+  dropdown.appendChild(trigger);
+  dropdown.appendChild(menu);
+
+  renameItem.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (typeof dropdown.hide === "function") dropdown.hide();
+    onRename?.(item);
+  });
+  deleteItem.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (typeof dropdown.hide === "function") dropdown.hide();
+    onDelete?.(item);
+  });
+
+  return dropdown;
+};
+
 const renderHistoryList = (listContainer, historyData, callbacks = {}) => {
   if (!listContainer) return;
   const boards = historyData?.data || [];
-  const { onItemSelect } = callbacks;
+  const { onItemSelect, onRename, onDelete } = callbacks;
 
   const sections = getHistorySectionsOrdered(boards);
 
@@ -85,11 +177,21 @@ const renderHistoryList = (listContainer, historyData, callbacks = {}) => {
       const li = document.createElement("li");
       li.className = "history-item-group-item";
       li.setAttribute("data-board-id", item?.id || "");
+
+      const row = document.createElement("div");
+      row.className = "history-item-group-item-row";
+
       const itemTitle = document.createElement("div");
       itemTitle.className = "history-item-group-item-title";
       itemTitle.textContent = item?.name || "Untitled";
-      li.appendChild(itemTitle);
-      li.addEventListener("click", () => {
+      row.appendChild(itemTitle);
+
+      const dropdown = createHistoryItemDropdown(item, { onRename, onDelete });
+      row.appendChild(dropdown);
+
+      li.appendChild(row);
+      li.addEventListener("click", (e) => {
+        if (e.target.closest("sl-dropdown") || e.target.closest(".eva-sdk-history-item-title-input")) return;
         hideRecentAgentsDiv("recent-agents-container");
         JoinChatThread({ boardId: item?.id });
         onItemSelect?.();
@@ -164,8 +266,14 @@ export const initHistoryList = (listContainer, callbacks = {}) => {
   if (!listContainer) return null;
 
   const historyInterface = HistoryInterface();
+  const callbacksWithHistory = {
+    ...callbacks,
+    onRename: (item) => startInlineRename(listContainer, item, historyInterface),
+    onDelete: (item) => historyInterface.deleteHistoryBoard(item),
+  };
+
   const unsubscribe = historyInterface.subscribe((allhistoryData) => {
-    renderHistoryList(listContainer, allhistoryData, callbacks);
+    renderHistoryList(listContainer, allhistoryData, callbacksWithHistory);
   });
 
   const removeScrollListener = setupScrollPagination(listContainer);
@@ -173,7 +281,7 @@ export const initHistoryList = (listContainer, callbacks = {}) => {
 
   const initialHistory = store.getState()?.global?.AllHistory;
   if (initialHistory?.data) {
-    renderHistoryList(listContainer, { data: initialHistory.data, hasMore: initialHistory.hasMore }, callbacks);
+    renderHistoryList(listContainer, { data: initialHistory.data, hasMore: initialHistory.hasMore }, callbacksWithHistory);
   }
 
   return {

--- a/src/chatbot/chatbotHistory.js
+++ b/src/chatbot/chatbotHistory.js
@@ -1,0 +1,186 @@
+import { HistoryInterface } from "../history";
+import { JoinChatThread } from "../chat";
+import LoadMoreHistoryData from "../history/LoadMoreHistoryData";
+import store from "../redux/store";
+import { hideRecentAgentsDiv } from "../LandingPageRecentAgents";
+import { segregateHistoryBySections, HISTORY_SECTIONS } from "../utils/helpers";
+
+
+const getHistorySectionsOrdered = (items, timeZone) => {
+  const { today, yesterday, last7Days, last30Days, older } = segregateHistoryBySections(items, timeZone);
+  const out = [];
+  if (today.length) out.push({ sectionTitle: HISTORY_SECTIONS.TODAY, items: today });
+  if (yesterday.length) out.push({ sectionTitle: HISTORY_SECTIONS.YESTERDAY, items: yesterday });
+  if (last7Days.length) out.push({ sectionTitle: HISTORY_SECTIONS.LAST_7_DAYS, items: last7Days });
+  if (last30Days.length) out.push({ sectionTitle: HISTORY_SECTIONS.LAST_30_DAYS, items: last30Days });
+  if (older.length) out.push({ sectionTitle: HISTORY_SECTIONS.OLDER, items: older });
+  return out;
+};
+
+
+export const createHistorySidebar = () => {
+  const overlay = document.createElement("div");
+  overlay.className = "eva-sdk-chatbot-history-overlay";
+  overlay.setAttribute("aria-hidden", "true");
+
+  const sidebar = document.createElement("aside");
+  sidebar.className = "eva-sdk-chatbot-history-sidebar";
+  sidebar.setAttribute("role", "dialog");
+  sidebar.setAttribute("aria-label", "Chat History");
+  sidebar.setAttribute("aria-modal", "true");
+
+  const header = document.createElement("div");
+  header.className = "eva-sdk-chatbot-history-header";
+
+  const title = document.createElement("div");
+  title.className = "eva-sdk-chatbot-history-title";
+  title.textContent = "Chat History";
+
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.className = "eva-sdk-chatbot-history-close";
+  closeButton.setAttribute("aria-label", "Close chat history");
+  closeButton.innerHTML = "×";
+
+  header.appendChild(title);
+  header.appendChild(closeButton);
+
+  const body = document.createElement("div");
+  body.className = "eva-sdk-chatbot-history-body";
+
+  const content = document.createElement("div");
+  content.className = "eva-sdk-chatbot-history-content";
+  content.innerHTML = '<div class="eva-sdk-chatbot-history-list"></div>';
+  body.appendChild(content);
+
+  sidebar.appendChild(header);
+  sidebar.appendChild(body);
+  overlay.appendChild(sidebar);
+
+  sidebar.addEventListener("click", (e) => e.stopPropagation());
+
+  return { overlay, sidebar, closeButton, body, content };
+};
+
+
+const renderHistoryList = (listContainer, historyData, callbacks = {}) => {
+  if (!listContainer) return;
+  const boards = historyData?.data || [];
+  const { onItemSelect } = callbacks;
+
+  const sections = getHistorySectionsOrdered(boards);
+
+  const fragment = document.createDocumentFragment();
+  sections.forEach(({ sectionTitle, items }) => {
+    const group = document.createElement("div");
+    group.className = "history-item-group";
+    const titleEl = document.createElement("div");
+    titleEl.className = "history-item-group-title";
+    titleEl.textContent = sectionTitle;
+    group.appendChild(titleEl);
+
+    const ul = document.createElement("ul");
+    ul.className = "history-item-group-items";
+    items.forEach((item) => {
+      const li = document.createElement("li");
+      li.className = "history-item-group-item";
+      li.setAttribute("data-board-id", item?.id || "");
+      const itemTitle = document.createElement("div");
+      itemTitle.className = "history-item-group-item-title";
+      itemTitle.textContent = item?.name || "Untitled";
+      li.appendChild(itemTitle);
+      li.addEventListener("click", () => {
+        hideRecentAgentsDiv("recent-agents-container");
+        JoinChatThread({ boardId: item?.id });
+        onItemSelect?.();
+      });
+      ul.appendChild(li);
+    });
+    group.appendChild(ul);
+    fragment.appendChild(group);
+  });
+
+  listContainer.replaceChildren(fragment);
+};
+
+const createHistoryLoader = () => {
+  const wrap = document.createElement("div");
+  wrap.className = "eva-sdk-chatbot-history-loader";
+  wrap.setAttribute("aria-hidden", "true");
+  wrap.innerHTML = `
+    <div class="eva-sdk-chatbot-history-loader-spinner"></div>
+    <span class="eva-sdk-chatbot-history-loader-text">Loading...</span>
+  `;
+  return wrap;
+};
+
+const setupLoadingIndicator = (listContainer) => {
+  const content = listContainer?.parentElement;
+  if (!content) return () => {};
+
+  const loader = createHistoryLoader();
+  content.appendChild(loader);
+
+  const updateVisibility = () => {
+    const isLoading = store.getState()?.global?.AllHistory?.status === "loading";
+    loader.classList.toggle("eva-sdk-chatbot-history-loader--visible", isLoading);
+    loader.setAttribute("aria-hidden", String(!isLoading));
+  };
+
+  updateVisibility();
+  const unsubscribe = store.subscribe(updateVisibility);
+
+  return () => {
+    unsubscribe();
+    loader.remove();
+  };
+};
+
+const SCROLL_LOAD_THRESHOLD_PX = 80;
+const LOAD_MORE_LIMIT = 10;
+
+const setupScrollPagination = (listContainer) => {
+  const scrollContainer = listContainer?.closest(".eva-sdk-chatbot-history-body");
+  if (!scrollContainer) return () => {};
+
+  const onScroll = () => {
+    const { scrollTop, clientHeight, scrollHeight } = scrollContainer;
+    const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+    if (distanceFromBottom > SCROLL_LOAD_THRESHOLD_PX) return;
+
+    const { AllHistory } = store.getState()?.global || {};
+    const hasMore = Boolean(AllHistory?.hasMore);
+    const isLoading = AllHistory?.status === "loading";
+    if (!hasMore || isLoading) return;
+
+    LoadMoreHistoryData({ limit: LOAD_MORE_LIMIT });
+  };
+
+  scrollContainer.addEventListener("scroll", onScroll, { passive: true });
+  return () => scrollContainer.removeEventListener("scroll", onScroll);
+};
+
+export const initHistoryList = (listContainer, callbacks = {}) => {
+  if (!listContainer) return null;
+
+  const historyInterface = HistoryInterface();
+  const unsubscribe = historyInterface.subscribe((allhistoryData) => {
+    renderHistoryList(listContainer, allhistoryData, callbacks);
+  });
+
+  const removeScrollListener = setupScrollPagination(listContainer);
+  const removeLoadingIndicator = setupLoadingIndicator(listContainer);
+
+  const initialHistory = store.getState()?.global?.AllHistory;
+  if (initialHistory?.data) {
+    renderHistoryList(listContainer, { data: initialHistory.data, hasMore: initialHistory.hasMore }, callbacks);
+  }
+
+  return {
+    unsubscribe: () => {
+      unsubscribe();
+      removeScrollListener();
+      removeLoadingIndicator();
+    },
+  };
+};

--- a/src/styles/chatbot.scss
+++ b/src/styles/chatbot.scss
@@ -486,7 +486,54 @@
             }
           }
         }
+        .history-loadmore {
+          padding: 8px 16px;
+          .loadmore-btn {
+            width: 100%;
+            padding: 8px 12px;
+            font-size: 14px;
+            color: #0f5bf0;
+            background: transparent;
+            border: 1px solid rgba(15, 91, 240, 0.4);
+            border-radius: 8px;
+            cursor: pointer;
+            transition: background-color 0.2s ease;
+            &:hover {
+              background: rgba(15, 91, 240, 0.08);
+            }
+          }
+        }
+      }
+
+      .eva-sdk-chatbot-history-loader {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        padding: 16px;
+        font-size: 14px;
+        color: #70707B;
+        &.eva-sdk-chatbot-history-loader--visible {
+          display: flex;
+        }
+        .eva-sdk-chatbot-history-loader-spinner {
+          width: 20px;
+          height: 20px;
+          border: 2px solid rgba(15, 91, 240, 0.2);
+          border-top-color: #0f5bf0;
+          border-radius: 50%;
+          animation: eva-sdk-chatbot-history-spin 0.7s linear infinite;
+        }
+        .eva-sdk-chatbot-history-loader-text {
+          font-family: Inter, sans-serif;
+        }
       }
     }
+  }
+}
+
+@keyframes eva-sdk-chatbot-history-spin {
+  to {
+    transform: rotate(360deg);
   }
 }

--- a/src/styles/chatbot.scss
+++ b/src/styles/chatbot.scss
@@ -414,15 +414,15 @@
   }
   .eva-sdk-chatbot-history-body {
     padding: 12px 16px 12px 0;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
     color: #344054;
     font-size: 14px;
-    overflow-y: auto;
     flex-grow: 1;
     min-height: 0;
 
     .eva-sdk-chatbot-history-content {
-      height: 100%;
+      /* No fixed height so content grows with list and body shows scrollbar when needed */
 
       .eva-sdk-chatbot-history-list {
         display: flex;
@@ -477,11 +477,62 @@
               &:hover {
                 background: rgba(229, 229, 229, .25);
               }
+              .history-item-group-item-row {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                min-width: 0;
+                flex: 1;
+              }
               .history-item-group-item-title {
-                max-width: 100%;
+                min-width: 0;
+                flex: 1;
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
+              }
+              .eva-sdk-history-item-title-input {
+                min-width: 0;
+                flex: 1;
+                font-family: Inter;
+                font-size: 14px;
+                font-weight: 400;
+                line-height: 20px;
+                color: #111827;
+                border: 1px solid #0f5bf0;
+                border-radius: 6px;
+                padding: 4px 8px;
+                background: #fff;
+                outline: none;
+              }
+              .eva-sdk-history-item-menu-trigger {
+                flex-shrink: 0;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 28px;
+                height: 28px;
+                padding: 0;
+                border: none;
+                border-radius: 6px;
+                background: transparent;
+                cursor: pointer;
+                opacity: 0;
+                transition: opacity 0.2s ease, background-color 0.2s ease;
+                .eva-sdk-history-item-menu-icon {
+                  display: block;
+                  pointer-events: none;
+                }
+                &:hover {
+                  background: rgba(0, 0, 0, 0.06);
+                }
+                &:focus-visible {
+                  outline: 2px solid rgba(15, 91, 240, 0.5);
+                  outline-offset: 1px;
+                }
+              }
+              &:hover .eva-sdk-history-item-menu-trigger {
+                opacity: 1;
               }
             }
           }
@@ -536,4 +587,44 @@
   to {
     transform: rotate(360deg);
   }
+}
+
+/* History item dropdown menu - hoist so panel is not clipped by sidebar overflow */
+.eva-sdk-history-item-dropdown {
+  flex-shrink: 0;
+  display: inline-flex;
+}
+.eva-sdk-history-item-dropdown::part(panel) {
+  z-index: 10000;
+  padding: 4px 0;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  min-width: 120px;
+  background: #fff;
+  overflow: visible;
+}
+.eva-sdk-history-item-dropdown sl-menu.eva-sdk-history-item-menu {
+  border: none;
+  background: #fff;
+  padding: 4px 0;
+  display: block;
+  min-width: 120px;
+}
+.eva-sdk-history-item-dropdown sl-menu-item {
+  font-family: Inter;
+  font-size: 14px;
+  cursor: pointer;
+  color: #111827;
+  padding: 8px 12px;
+  display: block;
+  white-space: nowrap;
+}
+.eva-sdk-history-item-dropdown sl-menu-item:hover {
+  background: #f3f4f6;
+}
+/* Ensure Shoelace menu items are visible (they use shadow DOM parts) */
+.eva-sdk-history-item-dropdown sl-menu-item::part(base) {
+  color: #111827;
+  padding: 8px 12px;
 }

--- a/src/styles/chatbot.scss
+++ b/src/styles/chatbot.scss
@@ -243,6 +243,8 @@
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   background: #f8f9fb;
   border-radius: 16px 16px 0 0;
+  height: 60px;
+  flex-shrink: 0;
 
   .eva-sdk-chatbot-header-buttons {
     display: flex;
@@ -360,6 +362,7 @@
   &.eva-sdk-chatbot-history-overlay--open {
     opacity: 1;
     pointer-events: auto;
+    overscroll-behavior: contain;
   }
   .eva-sdk-chatbot-history-sidebar {
     position: absolute;
@@ -385,6 +388,7 @@
     border-bottom: 1px solid rgba(0, 0, 0, 0.08);
     background: #f8f9fb;
     flex-shrink: 0;
+    height: 60px;
   }
   
   .eva-sdk-chatbot-history-title {
@@ -420,6 +424,7 @@
     font-size: 14px;
     flex-grow: 1;
     min-height: 0;
+    overscroll-behavior: contain;
 
     .eva-sdk-chatbot-history-content {
       /* No fixed height so content grows with list and body shows scrollbar when needed */
@@ -477,6 +482,12 @@
               &:hover {
                 background: rgba(229, 229, 229, .25);
               }
+              &.active {
+                background: rgba(229, 229, 229, .25);
+                .eva-sdk-history-item-menu-trigger {
+                  opacity: 1;
+                }
+              }
               .history-item-group-item-row {
                 display: flex;
                 align-items: center;
@@ -498,23 +509,27 @@
                 font-size: 14px;
                 font-weight: 400;
                 line-height: 20px;
-                color: #111827;
-                border: 1px solid #0f5bf0;
-                border-radius: 6px;
+                color: #141414;
+                border: 1px solid #d6d6d6;
+                border-radius: 8px;
                 padding: 4px 8px;
                 background: #fff;
                 outline: none;
+                &:focus-visible {
+                  border: 0.0625rem solid var(--Gray-iron-200, #E4E4E7) !important;
+                  box-shadow: 0px 0px 0px 2px #F2F4F7 !important;
+                }
               }
               .eva-sdk-history-item-menu-trigger {
                 flex-shrink: 0;
                 display: inline-flex;
                 align-items: center;
                 justify-content: center;
-                width: 28px;
-                height: 28px;
+                width: 20px;
+                height: 20px;
                 padding: 0;
                 border: none;
-                border-radius: 6px;
+                border-radius: 100px;
                 background: transparent;
                 cursor: pointer;
                 opacity: 0;
@@ -522,13 +537,17 @@
                 .eva-sdk-history-item-menu-icon {
                   display: block;
                   pointer-events: none;
+                  padding: 2px 0 2px 2px;
                 }
                 &:hover {
-                  background: rgba(0, 0, 0, 0.06);
+                  background: #fff;
                 }
                 &:focus-visible {
-                  outline: 2px solid rgba(15, 91, 240, 0.5);
+                  outline: 1px solid rgba(0, 0, 0, 1);
                   outline-offset: 1px;
+                }
+                &[aria-expanded="true"] {
+                  background: #fff;
                 }
               }
               &:hover .eva-sdk-history-item-menu-trigger {
@@ -593,30 +612,44 @@
 .eva-sdk-history-item-dropdown {
   flex-shrink: 0;
   display: inline-flex;
+
+  .menu-item__label {
+    font-family: Inter;
+    font-size: .75rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 1.125rem;
+    letter-spacing: 0em;
+    color: #424242;
+  }
 }
 .eva-sdk-history-item-dropdown::part(panel) {
   z-index: 10000;
-  padding: 4px 0;
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  min-width: 120px;
+  min-width: 7.5rem;
   background: #fff;
   overflow: visible;
+  border: .0625rem solid #e5e5e5;
+  border-radius: 1rem;
+  padding: .5rem;
+  box-shadow: 0rem .75rem 1rem -0.25rem rgba(16, 24, 40, .0784313725);
 }
 .eva-sdk-history-item-dropdown sl-menu.eva-sdk-history-item-menu {
   border: none;
   background: #fff;
-  padding: 4px 0;
+  padding: 0 0;
   display: block;
-  min-width: 120px;
+  min-width: 7.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 .eva-sdk-history-item-dropdown sl-menu-item {
   font-family: Inter;
   font-size: 14px;
   cursor: pointer;
   color: #111827;
-  padding: 8px 12px;
+  padding: .25rem .5rem;
+  border-radius: .75rem;
   display: block;
   white-space: nowrap;
 }
@@ -626,5 +659,43 @@
 /* Ensure Shoelace menu items are visible (they use shadow DOM parts) */
 .eva-sdk-history-item-dropdown sl-menu-item::part(base) {
   color: #111827;
-  padding: 8px 12px;
+  padding: 0;
+}
+
+/* Hide Shoelace built-in checked icon + submenu chevron */
+.eva-sdk-history-item-dropdown sl-menu-item::part(checked-icon) {
+  display: none;
+}
+.eva-sdk-history-item-dropdown sl-menu-item::part(submenu-icon) {
+  display: none;
+}
+/* Extra safety: if a chevron is rendered as suffix in some variants */
+.eva-sdk-history-item-dropdown sl-menu-item::part(suffix) {
+  display: none;
+}
+
+
+
+/* Destructive action styling */
+.eva-sdk-history-item-dropdown sl-menu-item.eva-sdk-history-menu-item--delete:hover {
+  background: #fef3f2;
+}
+.eva-sdk-history-item-dropdown sl-menu-item.eva-sdk-history-menu-item--delete::part(base) {
+  color: #f04438;
+  background: transparent;
+}
+
+.eva-sdk-history-item-dropdown .eva-sdk-history-menu-item-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+}
+
+.eva-sdk-history-item-dropdown .eva-sdk-history-menu-item-icon svg {
+  display: block;
+  width: 16px;
+  height: 16px;
 }

--- a/src/styles/chatbot.scss
+++ b/src/styles/chatbot.scss
@@ -297,6 +297,7 @@
   font-weight: 600;
   color: #111827;
 }
+
 .eva-sdk-chatbot-body {
   flex: 1;
   min-height: 0;
@@ -340,5 +341,152 @@
 
   .eva-sdk-chatbot-header {
     border-radius: 0;
+  }  
+}
+
+
+/* Chat History sidebar */
+.eva-sdk-chatbot-history-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 5;
+  background: rgba(15, 23, 42, 0.2);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  overflow: hidden;
+  border-radius: 16px;
+
+  &.eva-sdk-chatbot-history-overlay--open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .eva-sdk-chatbot-history-sidebar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: min(50%, 92vw);
+    background: #ffffff;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.22);
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    display: flex;
+    flex-direction: column;
+  }
+  .eva-sdk-chatbot-history-sidebar--open {
+    transform: translateX(0);
+  }
+  .eva-sdk-chatbot-history-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    background: #f8f9fb;
+    flex-shrink: 0;
+  }
+  
+  .eva-sdk-chatbot-history-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #111827;
+  }
+  
+  .eva-sdk-chatbot-history-close {
+    border: 1px solid #d0d5dd;
+    background: #fff;
+    font-size: 20px;
+    line-height: 1;
+    cursor: pointer;
+    color: #111827;
+    transition: all 0.2s ease;
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 100%;
+  
+    &:hover {
+      color: #0f5bf0;
+    }
+  }
+  .eva-sdk-chatbot-history-body {
+    padding: 12px 16px 12px 0;
+    overflow: auto;
+    color: #344054;
+    font-size: 14px;
+    overflow-y: auto;
+    flex-grow: 1;
+    min-height: 0;
+
+    .eva-sdk-chatbot-history-content {
+      height: 100%;
+
+      .eva-sdk-chatbot-history-list {
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+
+        .history-item-group {
+          display: flex;
+          flex-direction: column;
+          gap: 4px;
+
+          .history-item-group-title {
+            font-family: Inter;
+            font-size: 12px;
+            font-style: normal;
+            font-weight: 400;
+            line-height: 18px;
+            letter-spacing: 0em;
+            color: #70707B;
+            padding-left: 16px;
+          }
+          .history-item-group-items {
+            margin: 0;
+            padding: 0 0 0 8px;
+            list-style: none;
+            display: flex;
+            flex-direction: column;
+
+            .history-item-group-item {
+              list-style-type: none;
+              display: flex;
+              padding: 8px 12px 8px 16px;
+              align-items: center;
+              justify-content: space-between;
+              gap: 8px;
+              align-self: stretch;
+              border-radius: 12px;
+              height: 36px;
+              cursor: pointer;
+              transition: background-color .3s ease;
+              font-family: Inter;
+              font-size: 14px;
+              font-style: normal;
+              font-weight: 400;
+              line-height: 20px;
+              letter-spacing: 0em;
+              position: relative;
+              white-space: nowrap;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              max-width: 100%;
+              &:hover {
+                background: rgba(229, 229, 229, .25);
+              }
+              .history-item-group-item-title {
+                max-width: 100%;
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+              }
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/src/styles/chatbot.scss
+++ b/src/styles/chatbot.scss
@@ -625,7 +625,7 @@
 }
 .menu-item .menu-item__label {
   font-family: Inter;
-  font-size: .875rem;
+  font-size: .75rem;
   font-style: normal;
   font-weight: 500;
   line-height: 1.125rem;

--- a/src/styles/chatbot.scss
+++ b/src/styles/chatbot.scss
@@ -623,6 +623,15 @@
     color: #424242;
   }
 }
+.menu-item .menu-item__label {
+  font-family: Inter;
+  font-size: .875rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.125rem;
+  letter-spacing: 0em;
+  color: #424242;
+}
 .eva-sdk-history-item-dropdown::part(panel) {
   z-index: 10000;
   min-width: 7.5rem;

--- a/src/templateRenderer/icons-library.js
+++ b/src/templateRenderer/icons-library.js
@@ -228,6 +228,16 @@ export function EllipsisVertical({ size = config.size, color = config.color, cla
   `
 }
 
+export function EllipsisHorizontal({ size = config.size, color = config.color, className = '' } = {}) {
+  return `
+    <svg width="${size}" height="${size}" viewBox="0 0 14 3" fill="none" xmlns="http://www.w3.org/2000/svg" class="wa-EllipsisHorizontal ${className}">
+      <path d="M2.02222 1.46667C2.02222 2.15396 1.46506 2.71112 0.777771 2.71112C0.090485 2.71112 -0.466675 2.15396 -0.466675 1.46667C-0.466675 0.779386 0.090485 0.222229 0.777771 0.222229C1.46506 0.222229 2.02222 0.779386 2.02222 1.46667Z" fill="${color}"/>
+      <path d="M6.99999 1.46667C6.99999 2.15396 6.44284 2.71112 5.75555 2.71112C5.06826 2.71112 4.51111 2.15396 4.51111 1.46667C4.51111 0.779386 5.06826 0.222229 5.75555 0.222229C6.44284 0.222229 6.99999 0.779386 6.99999 1.46667Z" fill="${color}"/>
+      <path d="M11.9778 1.46667C11.9778 2.15396 11.4206 2.71112 10.7333 2.71112C10.046 2.71112 9.48889 2.15396 9.48889 1.46667C9.48889 0.779386 10.046 0.222229 10.7333 0.222229C11.4206 0.222229 11.9778 0.779386 11.9778 1.46667Z" fill="${color}"/>
+    </svg>
+  `
+}
+
 export function Gmail({ size = config.size, color = config.color, className = '' }) {
   return `
       <svg width="${size}" height="${size}" className="wa-Gmail ${className}" viewBox="0 0 12 9" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -496,3 +496,87 @@ export function markdownToPlainText(md) {
 
 const trimWithEllipsis = (str, max=100) =>
   str.length > max ? str.slice(0, max) + "..." : str;
+
+/**
+ * Section keys for segregated history (display order).
+ */
+export const HISTORY_SECTIONS = {
+    TODAY: "Today",
+    YESTERDAY: "Yesterday",
+    LAST_7_DAYS: "Last 7 days",
+    LAST_30_DAYS: "Last 30 days",
+    OLDER: "Older",
+};
+
+/* Returns YYYY-MM-DD for consistent string comparison. Uses en-CA in timezone when provided. */
+const getDateStringInZone = (date, timeZone) => {
+    if (timeZone) {
+        return date.toLocaleDateString("en-CA", { timeZone });
+    }
+    const y = date.getFullYear();
+    const m = String(date.getMonth() + 1).padStart(2, "0");
+    const d = String(date.getDate()).padStart(2, "0");
+    return `${y}-${m}-${d}`;
+};
+
+/* Normalize createdOn: API may return seconds (e.g. Unix) or milliseconds. */
+const normalizeCreatedOn = (ts) => {
+    if (ts == null || typeof ts !== "number") return ts;
+    if (ts < 1e12) return ts * 1000;
+    return ts;
+};
+
+export const segregateHistoryBySections = (items, timeZone) => {
+    const result = {
+        today: [],
+        yesterday: [],
+        last7Days: [],
+        last30Days: [],
+        older: [],
+    };
+    if (!Array.isArray(items) || items.length === 0) return result;
+
+    const now = new Date();
+    const todayStr = getDateStringInZone(now, timeZone);
+
+    const yesterdayDate = new Date(now);
+    yesterdayDate.setDate(yesterdayDate.getDate() - 1);
+    const yesterdayStr = getDateStringInZone(yesterdayDate, timeZone);
+
+    const sevenDaysAgoDate = new Date(now);
+    sevenDaysAgoDate.setDate(sevenDaysAgoDate.getDate() - 7);
+    const sevenDaysAgoStr = getDateStringInZone(sevenDaysAgoDate, timeZone);
+
+    const thirtyDaysAgoDate = new Date(now);
+    thirtyDaysAgoDate.setDate(thirtyDaysAgoDate.getDate() - 30);
+    const thirtyDaysAgoStr = getDateStringInZone(thirtyDaysAgoDate, timeZone);
+
+    for (const item of items) {
+        const raw = item?.createdOn;
+        if (raw == null) {
+            result.older.push(item);
+            continue;
+        }
+        const ts = normalizeCreatedOn(raw);
+        const itemDate = new Date(ts);
+        if (Number.isNaN(itemDate.getTime())) {
+            result.older.push(item);
+            continue;
+        }
+        const itemStr = getDateStringInZone(itemDate, timeZone);
+
+        if (itemStr === todayStr) {
+            result.today.push(item);
+        } else if (itemStr === yesterdayStr) {
+            result.yesterday.push(item);
+        } else if (itemStr >= sevenDaysAgoStr && itemStr < yesterdayStr) {
+            result.last7Days.push(item);
+        } else if (itemStr >= thirtyDaysAgoStr && itemStr < sevenDaysAgoStr) {
+            result.last30Days.push(item);
+        } else {
+            result.older.push(item);
+        }
+    }
+
+    return result;
+};


### PR DESCRIPTION
Added history section support chat window

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chatbot UI state/DOM event handling and wires into Redux/history subscription and pagination, which could introduce UX regressions or performance issues if listeners/state toggles misbehave.
> 
> **Overview**
> Adds an in-chat **Chat History** sidebar to the floating chatbot UI. The panel now includes a `Chat History` button that toggles an overlay sidebar, closes on overlay/close click, and is reset when the main chat closes.
> 
> Introduces `chatbotHistory.js` to render history grouped by date sections (Today/Yesterday/Last 7/Last 30/Older), subscribe to history updates, join a selected thread, and auto-load more history on scroll with a Redux-backed loading indicator. Updates `helpers.js` with `segregateHistoryBySections` (timestamp normalization + optional timezone) and adds comprehensive SCSS for the sidebar/loader styling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3a7e6c27866123fe5424ef5dd1f1e91cad981f6. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->