### PR TITLE
Morgan file upload fix

### DIFF
--- a/src/Attachments/fileUpload.js
+++ b/src/Attachments/fileUpload.js
@@ -206,6 +206,7 @@ const FileUpload = (props) => {
         // console.log(msg, data, allFilesCount)
         let _selectedContext = {};
         _selectedContext.data = {};
+        if(state.selectedContext?.data?.sources) {
         let remainingFiles = state.selectedContext.data.sources.filter(file => file.uID !== data.uniqueID)
         let errorFiles = [...(state.selectedContext.data.error || [])];
         let fileWithError = {
@@ -218,6 +219,9 @@ const FileUpload = (props) => {
         _selectedContext.data.sessionId = state.selectedContext?.data?.sessionId
         _selectedContext.data.quickactions = state.selectedContext?.data?.quickactions  
         _selectedContext.data.error = errorFiles
+    }else{
+        _selectedContext.data.sources = [{...data, error: msg}]
+    }
         store.dispatch(setSelectedContext(_selectedContext))
         // Returning as an object with success as false for the client to know that the request could not be completed
         return;

--- a/src/Attachments/fileUpload.js
+++ b/src/Attachments/fileUpload.js
@@ -132,7 +132,7 @@ const FileUpload = (props) => {
         const uploadConfig = {
             file: file.file,
             userInfoId: userId,
-            fileContext: 'knowledge',
+            fileContext: 'runtime',
             userAccessToken: userAccessToken,
             mediaName: obj.mediaName,
             source: source,

--- a/src/chat/gptTemplate/MultiResponse.js
+++ b/src/chat/gptTemplate/MultiResponse.js
@@ -168,7 +168,7 @@ const MultiResponse = () => {
         // Submit Button Action for the GPT Form
         event?.preventDefault()
         const state = store.getState().global;
-        const uploadedFiles = state.GptUploadedFiles;
+        const uploadedFiles = state.GptUploadedFiles;  
 
         let payload = {}
         payload.formData = {}
@@ -279,12 +279,21 @@ const MultiResponse = () => {
 
         // Constructing requestParams
         let requestParams = allResponseFields?.map((field, index) => {
+            let selectedPrompt = null;
+            /*check for the nested key in the fieldValues when key is prompts */
+            const nestedPromptCheck = field?.find(field => field?.key === "prompts" && field.value?.nested?.key === "prompt");
+            if(nestedPromptCheck){
+                const selectedPromptLabel = document.getElementById(`dropdownValue-${nestedPromptCheck?.key}-${item?.messageId}-${index}`)?.value;
+                selectedPrompt = nestedPromptCheck?.value?.choices?.find(choice => choice.label === selectedPromptLabel);
+            }
             let totalMockParameters = field?.reduce((acc, field) => {
                 let reqdInputElement;
-                let reqdValue;
+                let reqdValue; 
+                if(selectedPrompt && !selectedPrompt?.variables?.includes(field?.key) && field?.key !== "prompts"){
+                    return acc;
+                }
                 if (field?.value?.type === 'dropdown') {
-                    reqdInputElement = document.getElementById(`dropdownValue-${field?.key}-${item?.messageId}-${index}`);
-
+                    reqdInputElement = document.getElementById(`dropdownValue-${field?.key}-${item?.messageId}-${index}`);                    
                     if (field?.value?.multi) {
                         // For shoelace multi-select, value is already an array
                         reqdValue = reqdInputElement?.value || [];
@@ -302,6 +311,10 @@ const MultiResponse = () => {
                     if (field?.key === 'prompts') {
                         const promptId = field?.value?.choices?.find(choice => choice.label === reqdValue)?.id;
                         reqdValue = promptId || reqdValue;
+                        if(field?.value?.nested?.key === "prompt"){
+                            // reqdValue is the selected id (string); don't use reqdValue?.value
+                            selectedPrompt = field?.value?.choices?.find(choice => String(choice?.id) === String(reqdValue) || choice?.id == reqdValue);
+                        }
                     }
                     if (state?.enableDebugging) {
                         console.log(`Form field is ${`(dropdownValue-${field?.key})`} and value is {${reqdValue}}`)
@@ -332,20 +345,20 @@ const MultiResponse = () => {
                     acc[field.key].value = '';
                 }
 
-                if (field?.value?.nested?.key === "prompt" || field?.key === 'prompt') {
-                    // Need to send the Prompt Field Value as the prompt can be changed manually by the user if editable
-                    let promptField = document.getElementById(`inputValue-${field?.key}-${item?.messageId}-${index}`);
+                // if (field?.value?.nested?.key === "prompt" || field?.key === 'prompt') {
+                //     // Need to send the Prompt Field Value as the prompt can be changed manually by the user if editable
+                //     let promptField = document.getElementById(`inputValue-${field?.key}-${item?.messageId}-${index}`);
 
-                    // Check if it's a Quill editor or regular element
-                    let promptValue = "";
-                    if (promptField && promptField.quillEditor) {
-                        promptValue = promptField.quillEditor.getText();
-                    } else {
-                        promptValue = promptField?.value || promptField?.textContent || "";
-                    }
+                //     // Check if it's a Quill editor or regular element
+                //     let promptValue = "";
+                //     if (promptField && promptField.quillEditor) {
+                //         promptValue = promptField.quillEditor.getText();
+                //     } else {
+                //         promptValue = promptField?.value || promptField?.textContent || "";
+                //     }
 
-                    acc["prompt"] = promptValue;
-                }
+                //     acc["prompt"] = promptValue;
+                // }
 
                 // Checking if the Field has a file and getting the file from the uploadedFiles
                 if (field?.value?.canUploadFile) {
@@ -379,7 +392,7 @@ const MultiResponse = () => {
                 // }
 
                 // Checking if the Required Field is empty and returning an Error
-                if (field?.required || field?.value?.required) {
+                if ((field?.required || field?.value?.required)) {
                     if (reqdValue?.length === 0) {
                         throw new Error(`Required field ${field.label} is empty in ${index}th response.`);
                     }

--- a/src/chat/gptTemplate/gptFileUpload.js
+++ b/src/chat/gptTemplate/gptFileUpload.js
@@ -59,7 +59,7 @@ const uploadFileInitial = (file, id, resolve, reject) => {
     const uploadConfig = {
         file,
         userInfoId: userId,
-        fileContext: 'knowledge',
+        fileContext: 'runtime',
         userAccessToken: userAccessToken,
         mediaName: obj.mediaName,
         source: source

--- a/src/test-comp/MultiResponseTestComp.jsx
+++ b/src/test-comp/MultiResponseTestComp.jsx
@@ -7,11 +7,40 @@ import SubmitGPTForm from "../chat/gptTemplate/submitGPTForm";
 import RemoveUploadedGPTFile from "../chat/gptTemplate/removeUploadedGPTFile";
 import store from "../redux/store";
 import { use } from "marked";
-import { set } from "lodash";
+import { cloneDeep, set } from "lodash";
 
 const MultiResponseTestComp = ({ item }) => {        
-    let forms = item?.gpt_forms;
+    let _forms = cloneDeep(item?.gpt_forms);
     const [files, setFiles] = useState({})
+    const [forms, setForms] = useState(_forms);
+    const [selectedPrompt, setSelectedPrompt] = useState(null);
+
+    useEffect(() => {
+        console.log("_forms", _forms);
+        const _prompts = _forms?.fieldValues?.find(field => field?.key === "prompts");
+        /*check whether prompts is having nested key or not */
+        if(_prompts?.value?.nested){
+            setSelectedPrompt(_prompts?.choices?.[0]);
+        }
+        console.log("selectedPrompt", selectedPrompt);
+    }, []);
+
+    /** Read the selected option from a dropdown in the DOM using id dropdownValue-${key}-${messageId}-${subIndex} */
+    const getDropdownSelectedValue = (subItem, subIndex) => {
+        const id = `dropdownValue-${subItem?.key}-${item?.messageId}-${subIndex}`;
+        const selectEl = document.getElementById(id);
+        if (!selectEl) return null;
+        return selectEl.value; // value of the selected <option> (e.g. choice.label)
+    };
+
+    /** Same as above but returns the selected option element (for .textContent, .value, etc.) */
+    const getDropdownSelectedOption = (subItem, subIndex) => {
+        const id = `dropdownValue-${subItem?.key}-${item?.messageId}-${subIndex}`;
+        const selectEl = document.getElementById(id);
+        if (!selectEl || selectEl.selectedIndex < 0) return null;
+        return selectEl.options[selectEl.selectedIndex];
+    };
+
     return (
         <>
             <div>
@@ -19,16 +48,16 @@ const MultiResponseTestComp = ({ item }) => {
                     return (
                         <>
                             <div className='contextFiledHeader'>Context</div>
-                            {(contextField?.value?.type === "longText" || contextField?.value?.type === "richText") && (
+                            {((contextField?.value?.type === "longText" || contextField?.value?.type === "richText") && (!selectedPrompt || (selectedPrompt?.variables?.includes(contextField?.key)))) && (
                                 <>
                                     <div contentEditable="true" placeholder={contextField?.placeholder} value={contextField?.value} id={`inputValue-${contextField?.key}-${item?.messageId}`}></div>
                                 </>
                             )}
-                            {(contextField?.value?.type === "simpleText") && (
+                            {((contextField?.value?.type === "simpleText") && (!selectedPrompt || (selectedPrompt?.variables?.includes(contextField?.key)))) && (
                                 <div contentEditable="true" placeholder={contextField?.value?.placeholder} value={contextField?.value} id={`inputValue-${contextField?.key}-${item?.messageId}`}></div>
                             )}
 
-                            {(contextField?.value?.type === "file" || contextField?.value?.canUploadFile) && (
+                            {((contextField?.value?.type === "file" || contextField?.value?.canUploadFile) && (!selectedPrompt || (selectedPrompt?.variables?.includes(contextField?.key)))) && (
                                 <>
                                     <input type="file" id={`fileUpload-${contextField?.key}-${item?.messageId}`} multiple onChange={
                                         async (e) => {
@@ -68,7 +97,7 @@ const MultiResponseTestComp = ({ item }) => {
                             {fieldValue?.map((subItem, anotherIndex) => {
                                 return (
                                     <>
-                                        {(subItem?.value?.type === "dropdown" && subItem?.value?.multi) && (
+                                        {((subItem?.value?.type === "dropdown" && subItem?.value?.multi) && (!selectedPrompt || (selectedPrompt?.variables?.includes(subItem?.key)))) && (
                                             <>
                                                 <div>{subItem?.label}</div>
                                                 <select id={`dropdownValue-${subItem?.key}-${item?.messageId}-${subIndex}`} multiple>
@@ -78,7 +107,7 @@ const MultiResponseTestComp = ({ item }) => {
                                                 </select>
                                             </>
                                         )}
-                                        {(subItem?.value?.type === "dropdown" && !subItem?.value?.multi) && (
+                                        {((subItem?.value?.type === "dropdown" && !subItem?.value?.multi && subItem?.key !== "prompts") && (!selectedPrompt || (selectedPrompt?.variables?.includes(subItem?.key)))) && (
                                             <>
                                                 <div>{subItem?.label}</div>
                                                 <select id={`dropdownValue-${subItem?.key}-${item?.messageId}-${subIndex}`} >
@@ -88,25 +117,25 @@ const MultiResponseTestComp = ({ item }) => {
                                                 </select>
                                             </>
                                         )}
-                                        {(subItem?.value?.type === "simpleText") && (
+                                        {(subItem?.value?.type === "simpleText" && (!selectedPrompt || (selectedPrompt?.variables?.includes(subItem?.key)))) && (
                                             <>
                                                 <div>{subItem?.label}</div>
                                                 <div key={subIndex} value={subItem?.value} contentEditable="true" id={`inputValue-${subItem?.key}-${item?.messageId}-${subIndex}`} />
                                             </>
                                         )}
-                                        {(subItem?.value?.type === "number") && (
+                                        {(subItem?.value?.type === "number" && (!selectedPrompt || (selectedPrompt?.variables?.includes(subItem?.key)))) && (
                                             <>
                                                 <div>{subItem?.label}</div>
                                                 <input type="number" id={`inputValue-${subItem?.key}-${item?.messageId}-${subIndex}`} />
                                             </>
                                         )}
-                                        {(subItem?.value?.type === "longText") && (
+                                        {(subItem?.value?.type === "longText" && (!selectedPrompt || (selectedPrompt?.variables?.includes(subItem?.key)))) && (
                                             <>
                                                 <div>{subItem?.label}</div>
                                                 <div key={subIndex} value={subItem?.value} contentEditable="true" id={`inputValue-${subItem?.key}-${item?.messageId}-${subIndex}`} />
                                             </>
                                         )}
-                                        {(subItem?.value?.canUploadFile || subItem?.value?.type === 'file') && (
+                                        {((subItem?.value?.canUploadFile || subItem?.value?.type === 'file') && (!selectedPrompt || (selectedPrompt?.variables?.includes(subItem?.key)))) && (
                                             <>  
                                                 <input type="file" id={`fileUpload-${subItem?.key}-${item?.messageId}-${subIndex}`} multiple onChange={
                                                     async(e) => {
@@ -134,10 +163,30 @@ const MultiResponseTestComp = ({ item }) => {
                                             </>
                                         )}
                                         {subItem?.value?.nested?.key === "prompt" && (
-                                            <>  
-                                                <div>{subItem?.value?.nested?.label}</div>
-                                                <div id={`inputValue-${subItem?.key}-${item?.messageId}-${subIndex}`} contentEditable={subItem?.value?.nested?.readOnly ? false : true}>{subItem?.value?.nested?.value}</div>
-                                            </>
+                                            // <>  
+                                            //     <div>{subItem?.value?.nested?.label}</div>
+                                            //     <div id={`inputValue-${subItem?.key}-${item?.messageId}-${subIndex}`} contentEditable={subItem?.value?.nested?.readOnly ? false : true}>{subItem?.value?.nested?.value}</div>
+                                            // </>
+                                            <select
+                                                id={`dropdownValue-${subItem?.key}-${item?.messageId}-${subIndex}`}
+                                                value={selectedPrompt ? String(selectedPrompt?.label ?? "") : ""}
+                                                onChange={(e) => {
+                                                    const selectedLabel = e.target.value;
+                                                    const selectedChoice = subItem?.value?.choices?.find(
+                                                        (c) =>  c?.label === selectedLabel
+                                                    );
+                                                    if (selectedChoice) {
+                                                        setSelectedPrompt(selectedChoice);
+                                                    }
+                                                }}
+                                            >
+                                                {subItem?.value?.choices?.map((choice, choiceIndex) => (
+                                                    <option key={choice?.id ?? choiceIndex} value={String(choice?.label ?? "")}>
+                                                        {choice?.label}
+                                                    </option>
+                                                ))}
+
+                                            </select>
                                         )}
                                     </>
                                 )

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -38,8 +38,9 @@ export const getUID = function (len) {
 
 export const getFileExtension = (fileName) => {
     const parts = fileName?.split('.');
+    const supportedFileTypesForAttachments = store.getState().global.fileTypes.attachment;
     if (parts?.length > 1 && parts[parts?.length - 1].trim() !== '') {
-        if(supportedImagesOfFileUpload.includes(parts[parts?.length - 1].toLowerCase())) {
+        if(supportedFileTypesForAttachments.includes(parts[parts?.length - 1].toLowerCase())) {
             return parts[parts?.length - 1].toLowerCase()
         }
         return 'default';
@@ -48,7 +49,7 @@ export const getFileExtension = (fileName) => {
     }
 }
 
-export const supportedImagesOfFileUpload = ['csv', 'ppt', 'txt', 'pdf', 'doc', 'docx', 'text', 'txt', 'xls', 'xlsx']
+// export const supportedImagesOfFileUpload = ['csv', 'ppt', 'txt', 'pdf', 'doc', 'docx', 'text', 'txt', 'xls', 'xlsx']
 
 export const generateComponentId = () => {
     let cId = Math.random().toString(36).slice(2);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -38,7 +38,7 @@ export const getUID = function (len) {
 
 export const getFileExtension = (fileName) => {
     const parts = fileName?.split('.');
-    const supportedFileTypesForAttachments = store.getState().global.fileTypes.attachment;
+    const supportedFileTypesForAttachments = store.getState().global?.fileTypes?.attachment;
     if (parts?.length > 1 && parts[parts?.length - 1].trim() !== '') {
         if(supportedFileTypesForAttachments.includes(parts[parts?.length - 1].toLowerCase())) {
             return parts[parts?.length - 1].toLowerCase()


### PR DESCRIPTION
1. Changed fileContext for the upload files in runtime to 'runtime'
2. bug fix in case of dynamic gpt form for multi prompt
3. Modified the code such that uploading file types get data from config data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes attachment upload metadata and the dynamic GPT form submission logic, which could affect what files/fields are sent to backend APIs and trigger validation errors if the new prompt-variable filtering is wrong.
> 
> **Overview**
> Switches attachment/GPT file uploads to use `fileContext: 'runtime'` instead of `'knowledge'`, and makes attachment error handling more defensive when no prior `selectedContext.data.sources` exists.
> 
> Fixes dynamic multi-prompt GPT form submission by tracking the selected prompt, filtering request fields to only those variables used by that prompt (plus `prompts`), and correctly mapping the selected prompt dropdown label to the prompt `id` for `requestParams`. File extension detection now uses configured allowed attachment types from `global.fileTypes.attachment` rather than a hardcoded list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e452b207bafbe1e17f58871b658929f6ccba721d. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->